### PR TITLE
Add README in nuget package

### DIFF
--- a/PCAxis.Serializers/Serializers.csproj
+++ b/PCAxis.Serializers/Serializers.csproj
@@ -5,7 +5,7 @@
     <PackageId>PCAxis.Serializers</PackageId>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerDefaultPreReleasePhase>beta</MinVerDefaultPreReleasePhase>
-    <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>    
+    <MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright></Copyright>
@@ -15,34 +15,39 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>PX</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.15" />
-    
+
     <PackageReference Include="MinVer" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    
+
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Parquet.Net" Version="4.16.4" />
     <PackageReference Include="PCAxis.Core" Version="1.2.3" />
     <PackageReference Include="PCAxis.Metadata" Version="1.0.2" />
     <PackageReference Include="PCAxis.Query" Version="1.0.8" />
     <PackageReference Include="ClosedXML" Version="0.95.4" />
-    
+
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    
+
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    
+
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Include="..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="..\README.md">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>


### PR DESCRIPTION
Fixes waring on pulish to nuget
`WARNING: Readme missing. Go to https://aka.ms/nuget-include-readme learn How to include a readme file within the package.`