### PR TITLE
Bump ClosedXML from 0.95.4 to 0.97.0

### DIFF
--- a/PCAxis.Serializers/Serializers.csproj
+++ b/PCAxis.Serializers/Serializers.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="PCAxis.Core" Version="1.2.3" />
     <PackageReference Include="PCAxis.Metadata" Version="1.0.2" />
     <PackageReference Include="PCAxis.Query" Version="1.0.8" />
-    <PackageReference Include="ClosedXML" Version="0.95.4" />
+    <PackageReference Include="ClosedXML" Version="0.97.0" />
 
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>

--- a/PCAxis.Serializers/XlsxSerializer.cs
+++ b/PCAxis.Serializers/XlsxSerializer.cs
@@ -81,7 +81,7 @@ namespace PCAxis.Serializers
 		{
             if (value != null)
                 if (type == CellContentType.Comment)
-                    cell.Comment.AddText(value.ToString());
+                    cell.GetComment().AddText(value.ToString());
                 else
                     cell.SetValue(value); //Change from cell.Value = value to SetValue(..) For not format e.g 10-11 to date
 		}


### PR DESCRIPTION
Fixes a security issue [Remote Code Execution (RCE)](https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMDRAWINGCOMMON-3063427)

Release notes
https://github.com/ClosedXML/ClosedXML/releases/tag/0.96.0
https://github.com/ClosedXML/ClosedXML/releases/tag/0.97.0

There is also newer versions #28 but it requires som more work to fix breaking changes